### PR TITLE
Potential fix for code scanning alert no. 57: Server-side request forgery

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -31,7 +31,7 @@ public class SSRFTask2 implements AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig\\.pro")) {
+    if (isValidUrl(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =
@@ -49,6 +49,15 @@ public class SSRFTask2 implements AssignmentEndpoint {
     }
     var html = "<img class=\"image\" alt=\"image post\" src=\"images/cat.jpg\">";
     return getFailedResult(html);
+  }
+
+  private boolean isValidUrl(String url) {
+    try {
+      URL u = new URL(url);
+      return "http".equals(u.getProtocol()) && "ifconfig.pro".equals(u.getHost());
+    } catch (MalformedURLException e) {
+      return false;
+    }
   }
 
   private AttackResult getFailedResult(String errorMsg) {


### PR DESCRIPTION
Potential fix for [https://github.com/SONE-WorkshopPoligon/WebGoat/security/code-scanning/57](https://github.com/SONE-WorkshopPoligon/WebGoat/security/code-scanning/57)

To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a list of authorized URLs or restricted to a particular host. In this case, we can enhance the validation to ensure that the URL strictly matches the allowed pattern and does not include any potential bypass techniques.

1. Enhance the URL validation to ensure it strictly matches the allowed pattern.
2. Use a more robust method to validate the URL, such as checking the host and protocol explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
