### PR TITLE
Potential fix for code scanning alert no. 57: Server-side request forgery

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -54,8 +54,12 @@ public class SSRFTask2 implements AssignmentEndpoint {
   private boolean isValidUrl(String url) {
     try {
       URL u = new URL(url);
-      return "http".equals(u.getProtocol()) && "ifconfig.pro".equals(u.getHost());
-    } catch (MalformedURLException e) {
+      String host = u.getHost();
+      // Resolve the host to its canonical form to prevent DNS rebinding or IP-based bypasses
+      String resolvedHost = java.net.InetAddress.getByName(host).getHostName();
+      // Check against a whitelist of allowed hosts
+      return "ifconfig.pro".equals(resolvedHost) && "http".equals(u.getProtocol());
+    } catch (Exception e) {
       return false;
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/SONE-WorkshopPoligon/WebGoat/security/code-scanning/57](https://github.com/SONE-WorkshopPoligon/WebGoat/security/code-scanning/57)

To fix the SSRF vulnerability, we need to enhance the validation of the `url` parameter to ensure it cannot be exploited. The best approach is to maintain a whitelist of allowed URLs or domains and strictly validate the user input against this list. Additionally, we should resolve the URL to its canonical form (e.g., resolving DNS and IP addresses) to prevent bypasses using obfuscated or encoded URLs.

Steps to fix:
1. Replace the `isValidUrl` method with a more robust validation mechanism that resolves the URL to its canonical form and checks it against a whitelist.
2. Ensure that the `url` parameter is validated before being used to create a `URL` object or make any network requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
