### PR TITLE
Potential fix for code scanning alert no. 41: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
@@ -44,7 +44,9 @@ public class WebSecurityConfig {
               auth.requestMatchers(HttpMethod.POST, "/files", "/mail", "/requests").permitAll();
               auth.anyRequest().authenticated();
             })
-        .csrf(csrf -> csrf.disable())
+        .csrf(csrf -> 
+            csrf.ignoringRequestMatchers("/files", "/mail", "/requests") // Optional: Exclude specific endpoints
+        )
         .formLogin(
             login ->
                 login


### PR DESCRIPTION
Potential fix for [https://github.com/SONE-WorkshopPoligon/WebGoat/security/code-scanning/41](https://github.com/SONE-WorkshopPoligon/WebGoat/security/code-scanning/41)

To fix the issue, CSRF protection should be enabled by removing the `csrf.disable()` call. If there are specific endpoints or use cases that require CSRF protection to be bypassed, this can be achieved by customizing the CSRF configuration to exclude those endpoints while keeping protection enabled for the rest of the application.

**Steps to fix:**
1. Remove the `csrf.disable()` call from the `filterChain` method.
2. Optionally, configure CSRF protection to allow specific endpoints to bypass CSRF checks using `csrf.ignoringRequestMatchers()`.

**Required changes:**
- Modify the `filterChain` method in `WebSecurityConfig` to enable CSRF protection.
- Add any necessary configurations for endpoints that should bypass CSRF checks (if applicable).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
